### PR TITLE
Create fix_dds_for_mac.bat

### DIFF
--- a/After the End Fan Fork/gfx/fix_dds_for_mac.bat
+++ b/After the End Fan Fork/gfx/fix_dds_for_mac.bat
@@ -1,0 +1,1 @@
+FOR /R %%a IN (*.dds) DO convert "%%~a" "%%~dpna.dds"


### PR DESCRIPTION
DDSes sometimes only show up as blue, running this with imagemagick installed will fix all of the DDSes for mac by running a conversion on them (DDS->DDS)

Tested on my macbook air 2012